### PR TITLE
fix: season not proceeding without refresh page

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -3419,11 +3419,20 @@ export function nextTurn() {
   // Özet oluştur
   const summary = getTurnSummary(simResults);
 
-  return {
+  const result = {
     ...summary,
     ...winLoseResult,
     simWarnings: simResults.warnings,
   };
+
+  // Kazanma durumunda sandbox devam: modül flag'ını sıfırla.
+  // Kazanma sonucu result'a yakalandı, UI gösterecek.
+  // Kaybetme (gameOver) kalıcıdır — oyun gerçekten biter.
+  if (_gameWon && !_gameOver) {
+    _gameWon = false;
+  }
+
+  return result;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -3732,6 +3741,12 @@ export function getAccreditationPrestigeBonus(dept) {
 export function checkWinLose() {
   if (!_state) return { gameOver: false, gameWon: false, reason: null };
 
+  // Kazanma daha önce tetiklendiyse tekrar tetikleme (sandbox devam).
+  // Kaybetme koşulları hâlâ kontrol edilir.
+  if (_state._internal?.gameWonTriggered) {
+    return { gameOver: false, gameWon: false, reason: null };
+  }
+
   // ── KAYBETME KOŞULU 1: İflas ───────────────────────────────────────────────
   // Kredi sistemi: herhangi bir kredi 3 dönem ödenemezse loanDefault = true → iflas
 
@@ -3790,6 +3805,7 @@ export function checkWinLose() {
       if (scenarioWin.type === 'prestige' && _state.university.prestige >= scenarioWin.target) {
         _gameWon = true;
         _state._internal.gameWon = true;
+        _state._internal.gameWonTriggered = true;
         return {
           gameOver: false,
           gameWon:  true,
@@ -3802,6 +3818,7 @@ export function checkWinLose() {
       if (scenarioWin.type === 'ranking' && _state.university.ranking <= scenarioWin.target) {
         _gameWon = true;
         _state._internal.gameWon = true;
+        _state._internal.gameWonTriggered = true;
         return {
           gameOver: false,
           gameWon:  true,
@@ -3820,6 +3837,7 @@ export function checkWinLose() {
         if (_state.meta.scenarioPositiveTurns >= (scenarioWin.consecutiveTurns || 10)) {
           _gameWon = true;
           _state._internal.gameWon = true;
+          _state._internal.gameWonTriggered = true;
           return {
             gameOver: false,
             gameWon:  true,
@@ -3847,6 +3865,7 @@ export function checkWinLose() {
       if (_state.university.prestige >= 90) {
         _gameWon = true;
         _state._internal.gameWon = true;
+        _state._internal.gameWonTriggered = true;
         return {
           gameOver: false,
           gameWon:  true,
@@ -3859,6 +3878,7 @@ export function checkWinLose() {
       if (_state.university.ranking === 1) {
         _gameWon = true;
         _state._internal.gameWon = true;
+        _state._internal.gameWonTriggered = true;
         return {
           gameOver: false,
           gameWon:  true,

--- a/js/main.js
+++ b/js/main.js
@@ -653,7 +653,13 @@ function _onRenewAccreditation(deptId, bodyId) {
 }
 
 /** Oyun ekranına ait tüm event listener'ları bağla (bir kez çağrılır). */
+let _gameScreenEventsBound = false;
 function _bindGameScreenEvents() {
+  if (_gameScreenEventsBound) {
+    console.log('[main] Oyun ekranı event listener\'ları zaten bağlı, atlanıyor.');
+    return;
+  }
+  _gameScreenEventsBound = true;
   console.log('[main] Oyun ekranı event listener\'ları bağlanıyor...');
 
   // ── Sekme navigasyonu ───────────────────────────────────────────────────
@@ -743,11 +749,11 @@ function _onNextTurn() {
   // Oyun bittiyse/kazanıldıysa simülasyon yapma (Emir raporu — boş özet
   // modal'ı açılıyordu çünkü nextTurn() "Oyun zaten bitti." döndürüp
   // erken çıkıyor, ama UI hâlâ özet render ediyordu).
-  if (currentState.gameOver || currentState.gameWon) {
+  // Not: getState() klonu üst düzey gameOver/gameWon barındırmaz,
+  // bu bayraklar _internal altında saklanır.
+  if (currentState._internal?.gameOver) {
     showNotification(
-      currentState.gameWon
-        ? '🏆 Oyun kazanıldı. Yeni oyun başlatabilirsin.'
-        : 'Oyun bitti. Yeni oyun başlatabilirsin.',
+      'Oyun bitti. Yeni oyun başlatabilirsin.',
       'info',
       5000,
     );
@@ -784,9 +790,11 @@ function _runTurnAfterQuotas() {
 
   // Defensive: backend "Oyun zaten bitti." dönerse boş özet modal'ı açma
   // (Emir raporu — _onNextTurn'de zaten erken çıkış var, bu son güvenlik ağı).
-  if (state?.gameOver || state?.gameWon || /zaten bitti/i.test(summary?.message || '')) {
+  // Not: state (getState() klonu) üst düzey gameOver/gameWon barındırmaz,
+  // summary (nextTurn dönüşü) doğru değerleri taşır.
+  if (summary?.gameOver || /zaten bitti/i.test(summary?.message || '')) {
     showNotification(
-      state?.gameWon ? '🏆 Oyun kazanıldı. Yeni oyun başlatabilirsin.' : 'Oyun bitti. Yeni oyun başlatabilirsin.',
+      summary?.gameWon ? '🏆 Oyun kazanıldı. Yeni oyun başlatabilirsin.' : 'Oyun bitti. Yeni oyun başlatabilirsin.',
       'info',
       5000,
     );

--- a/js/ui.js
+++ b/js/ui.js
@@ -185,6 +185,10 @@ export function showModal(title, bodyHtml, opts = {}) {
 
   overlay.classList.remove('hidden');
   overlay.classList.add('active');
+
+  // Scroll'u en üste al
+  if (bodyEl) bodyEl.scrollTop = 0;
+  if (modalEl) modalEl.scrollTop = 0;
 }
 
 export function hideModal() {
@@ -6257,6 +6261,10 @@ export function renderTurnSummary(summary, onNextTurn) {
 
   overlay.classList.remove('hidden');
   overlay.classList.add('active');
+
+  // Scroll'u en üste al (içerik uzunsa altta başlamasın)
+  if (bodyEl) bodyEl.scrollTop = 0;
+  overlay.scrollTop = 0;
 
   on(el('btn-confirm-next-turn'), 'click', () => {
     overlay.classList.add('hidden');


### PR DESCRIPTION
Herhangi bir yılda dönem ilerle butonuna bastıktan sonra bir sonraki döneme geçip o dönemden sonra sayfayı yenilemeden bir sonraki döneme geçme hatası çözüldü.